### PR TITLE
Fix code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/server/qradviser/__init__.py
+++ b/server/qradviser/__init__.py
@@ -47,8 +47,11 @@ if settings.SERVE_STATIC is not None:
     @app.get('/{full_path:path}')
     async def spa(full_path:str):
         if full_path=="": full_path="index.html"
-        if os.path.exists(f"{settings.SERVE_STATIC}/"+full_path):
-            return FileResponse(f"{settings.SERVE_STATIC}/"+full_path)
+        full_path = os.path.normpath(f"{settings.SERVE_STATIC}/" + full_path)
+        if not full_path.startswith(settings.SERVE_STATIC):
+            raise HTTPException(status_code=403, detail="Forbidden")
+        if os.path.exists(full_path):
+            return FileResponse(full_path)
         else:
             return HTMLResponse(index)
 


### PR DESCRIPTION
Fixes [https://github.com/maru0123-2004/qrcode_advisor/security/code-scanning/2](https://github.com/maru0123-2004/qrcode_advisor/security/code-scanning/2)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. This can be achieved by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the root directory. This approach prevents path traversal attacks by ensuring that any `..` segments in the user input are resolved within the root directory.

1. Normalize the constructed file path using `os.path.normpath`.
2. Check that the normalized path starts with the root directory (`settings.SERVE_STATIC`).
3. If the check fails, return a 403 Forbidden response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
